### PR TITLE
Add default device status on UST-20LX

### DIFF
--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -160,8 +160,10 @@ void populateDiagnosticsStatus(diagnostic_updater::DiagnosticStatusWrapper &stat
     if(!urg_->isStarted())
     {
       stat.summary(2, "Not Connected: " + device_status_);
-    } 
-    else if(device_status_ != std::string("Sensor works well.") && device_status_ != std::string("Stable 000 no error."))
+    }
+    else if(device_status_ != std::string("Sensor works well.") &&
+            device_status_ != std::string("Stable 000 no error.") &&
+            device_status_ != std::string("sensor is working normally"))
     {
       stat.summary(2, "Abnormal status: " + device_status_);
     }


### PR DESCRIPTION
The UST-20LX (and I presume other new sensors from Hokuyo) report a device_status_ of "sensor is working normally" when all is well, which is different from earlier sensors. This causes the sensor to always report an error in diagnostics.
