### PR TITLE
Added option to publish max range readings as inf

### DIFF
--- a/include/urg_node/urg_c_wrapper.h
+++ b/include/urg_node/urg_c_wrapper.h
@@ -49,9 +49,9 @@ namespace urg_node
   class URGCWrapper
   {
   public:
-    URGCWrapper(const std::string& ip_address, const int ip_port, bool& using_intensity, bool& using_multiecho);
+    URGCWrapper(const std::string& ip_address, const int ip_port, bool& using_intensity, bool& using_multiecho, bool &no_range_as_inf);
 
-    URGCWrapper(const int serial_baud, const std::string& serial_port, bool& using_intensity, bool& using_multiecho);
+    URGCWrapper(const int serial_baud, const std::string& serial_port, bool& using_intensity, bool& using_multiecho, bool &no_range_as_inf);
 
     ~URGCWrapper();
 
@@ -122,7 +122,7 @@ namespace urg_node
     bool grabScan(const sensor_msgs::MultiEchoLaserScanPtr& msg);
 
   private:
-    void initialize(bool& using_intensity, bool& using_multiecho);
+    void initialize(bool& using_intensity, bool& using_multiecho, bool &no_range_as_inf);
 
     bool isIntensitySupported();
 
@@ -144,6 +144,7 @@ namespace urg_node
 
     bool use_intensity_;
     bool use_multiecho_;
+    bool no_range_as_inf_;
     urg_measurement_type_t measurement_type_;
     int first_step_;
     int last_step_;

--- a/src/getID.cpp
+++ b/src/getID.cpp
@@ -100,6 +100,7 @@ main(int argc, char** argv)
   
   bool publish_intensity = false;
   bool publish_multiecho = false;
+  bool publish_max_range_as_inf = false;
   int serial_baud = 115200;
   int ip_port = 10940;
   std::string ip_address = "";
@@ -125,9 +126,9 @@ main(int argc, char** argv)
 	// Set up the urgwidget
 	try{
 		if(ip_address != ""){
-			urg_.reset(new urg_node::URGCWrapper(ip_address, ip_port, publish_intensity, publish_multiecho));
+                  urg_.reset(new urg_node::URGCWrapper(ip_address, ip_port, publish_intensity, publish_multiecho, publish_max_range_as_inf));
 		} else {
-			urg_.reset(new urg_node::URGCWrapper(serial_baud, serial_port, publish_intensity, publish_multiecho));
+                  urg_.reset(new urg_node::URGCWrapper(serial_baud, serial_port, publish_intensity, publish_multiecho, publish_max_range_as_inf));
 		}
 		std::string device_id = urg_->getDeviceID();
 		if (verbose){

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -211,6 +211,9 @@ int main(int argc, char **argv)
   bool publish_multiecho;
   pnh.param<bool>("publish_multiecho", publish_multiecho, true);
 
+  bool no_range_as_inf;
+  pnh.param<bool>("no_range_as_inf", no_range_as_inf, false);
+
   int error_limit;
   pnh.param<int>("error_limit", error_limit, 4);
 
@@ -231,9 +234,9 @@ int main(int argc, char **argv)
     	urg_.reset(); // Clear any previous connections();
     	ros::Duration(1.0).sleep();
       if(ip_address != ""){
-        urg_.reset(new urg_node::URGCWrapper(ip_address, ip_port, publish_intensity, publish_multiecho));
+        urg_.reset(new urg_node::URGCWrapper(ip_address, ip_port, publish_intensity, publish_multiecho, no_range_as_inf));
       } else {
-        urg_.reset(new urg_node::URGCWrapper(serial_baud, serial_port, publish_intensity, publish_multiecho));
+        urg_.reset(new urg_node::URGCWrapper(serial_baud, serial_port, publish_intensity, publish_multiecho, no_range_as_inf));
       }
     } catch(std::runtime_error& e){
       ROS_ERROR_THROTTLE(10.0, "Error connecting to Hokuyo: %s", e.what());


### PR DESCRIPTION
In the costmap layers there is an option to use max range observations to clear the costmap (using raytracing) - by setting inf_is_valid to true. 

However, this driver publishes max range readings as nan - which makes it impossible to use this driver and clear the costmaps with max range readings. 

Added param to send max range readings as inf.

Set flag no_range_as_inf to true. 
