### PR TITLE
fix resize error

### DIFF
--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -85,6 +85,11 @@ void URGCWrapper::initialize(bool& using_intensity, bool& using_multiecho){
   if(urg_data_size  > 5000){  // Ocassionally urg_max_data_size returns a string pointer, make sure we don't allocate too much space, the current known max is 1440 steps
     urg_data_size = 5000;
   }
+  if(urg_data_size < 0){
+    std::stringstream ss;
+    ss << "urg_data_size is uncorrect: " << urg_data_size << "\n";
+    throw std::runtime_error(ss.str());
+  }
   data_.resize(urg_data_size * URG_MAX_ECHO);
   intensity_.resize(urg_data_size * URG_MAX_ECHO);
 


### PR DESCRIPTION
"Unknown error connecting to Hokuyo" is sometime happen even though opening a device is succeeded. It seems that communication between PC and urg is failed then urg_data_size become negative. An error message is added for this type of error in this source code.
