### PR TITLE
Add safety stop heading and distance values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS
   diagnostic_updater dynamic_reconfigure laser_proc message_generation
   nodelet rosconsole roscpp sensor_msgs std_msgs std_srvs tf urg_c
 )
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11")
 
 # Dynamic reconfigure support
 generate_dynamic_reconfigure_options(cfg/URG.cfg)

--- a/include/urg_node/urg_c_wrapper.h
+++ b/include/urg_node/urg_c_wrapper.h
@@ -69,6 +69,23 @@ public:
   bool lockout_status;
 };
 
+class UrgDetectionReport
+{
+public:
+  UrgDetectionReport()
+  {
+    status = 0;
+    area = 0;
+    distance = 0;
+    angle = 0;
+  }
+
+  uint16_t status;
+  uint16_t area;
+  uint16_t distance;
+  float angle;
+};
+
 class URGCWrapper
 {
 public:
@@ -145,6 +162,8 @@ public:
   bool grabScan(const sensor_msgs::MultiEchoLaserScanPtr& msg);
 
   bool getAR00Status(URGStatus& status);
+
+  bool getDL00Status(UrgDetectionReport& report);
 
 private:
   void initialize(bool& using_intensity, bool& using_multiecho);

--- a/msg/Status.msg
+++ b/msg/Status.msg
@@ -1,13 +1,9 @@
-# Reports the status of the 'AR00' message response from the laser.
-# This contains the error state and operating modes.
-uint16 status
-
 # Normal vs setting in the UAM manual.
 uint16 NORMAL=0
 uint16 SETTING=1
 uint16 operating_mode
 
-# AKA field set
+# The configured area number the stop occurred in.
 uint16 area_number
 # If the laser is reporting an error or not.
 bool error_status
@@ -15,3 +11,7 @@ bool error_status
 uint16 error_code
 # Does the laser report that it is locked out.
 bool lockout_status
+# Distance in mm the stop was reported at.
+uint16 distance
+# The reported angle of the stop in deg.
+float32 angle


### PR DESCRIPTION
Added to the laser status field the last report of a safety stop of distance and angle reported. If this fails or is unavailable it will just report 0.