### PR TITLE
Add flag to prevent updating of detailed status.

### DIFF
--- a/include/urg_node/urg_node_driver.h
+++ b/include/urg_node/urg_node_driver.h
@@ -121,6 +121,7 @@ private:
   int error_limit_;
   double diagnostics_tolerance_;
   double diagnostics_window_time_;
+  bool detailed_status_;
 
   volatile bool service_yield_;
 


### PR DESCRIPTION
If using a model that does not support AR00 command, hide it behind a rosparam.