### PR TITLE
Add backwards-compatible support for the Hokuyo URG-04LX

### DIFF
--- a/include/urg_node/urg_c_wrapper.h
+++ b/include/urg_node/urg_c_wrapper.h
@@ -179,6 +179,12 @@ private:
   ros::Duration getTimeStampOffset(size_t num_measurements);
 
   /**
+   * @brief Set the Hokuyo URG-04LX from SCIP 1.1 mode to SCIP 2.0 mode.
+   * @returns True if successful and false if not.
+   */
+  bool setToSCIP2();
+
+  /**
    * @brief calculate the crc of a given set of bytes.
    * @param bytes The bytes array to be processed.
    * @param size The size of the bytes array.


### PR DESCRIPTION
`urg_node` does not support SCIP 1.1, only SCIP 2.0.
However, the Hokuyo URG-04LX supports both SCIP 1.1 and SCIP 2.0 and usually defaults to SCIP 1.1.
It needs to be switched to SCIP 2.0 at every startup.

For this purpose the function `URGCWrapper::setToSCIP2` was added.
A Hokuyo URG-04LX in SCIP 1.1 mode lead to an exception in `URGCwrapper::initialize`. 
Now, before throwing the exception an attempt to switch the sensor to SCIP 2.0 mode is made using `URGCWrapper::setToSCIP2`. 

The `hokuyo_node` provides support for the URG-04LX in SCIP 1.1 mode in the same way.

I tested this patch successfully with the URG-04LX devices in our lab.
It doesn't break support for other devices because it only triggers as a last resort.

Please merge and release this into kinetic.

@v4hn

Fixes #23 