### PR TITLE
Recheck intensity support when restarting the driver

### DIFF
--- a/include/urg_node/urg_node_driver.h
+++ b/include/urg_node/urg_node_driver.h
@@ -119,6 +119,8 @@ private:
   bool synchronize_time_;
   bool publish_intensity_;
   bool publish_multiecho_;
+  bool intensity_enabled_;
+  bool multiecho_enabled_;
   int error_limit_;
   double diagnostics_tolerance_;
   double diagnostics_window_time_;


### PR DESCRIPTION
The check for intensity/multiecho support may fail due to a bad connection (eg. if powering or connecting a laser with urg_node already running).
If the driver then resets to fix this bad connection, it should re-test for intensity/multiecho support.