### PR TITLE
 [ros2] trim boost dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # we currently still rely on boost for its `crc` component
-# unfortunately, I haven't found a way to incorporate only crc
-# as a single components, hence including `thread` here.
-find_package(Boost COMPONENTS thread REQUIRED)
+find_package(Boost REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(laser_proc REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -38,9 +36,7 @@ target_include_directories(urg_node
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-  ${Boost_INCLUDE_DIR}
 )
-target_link_libraries(urg_node ${Boost_LIBRARIES})
 ament_target_dependencies(urg_node
   diagnostic_updater
   laser_proc
@@ -50,6 +46,7 @@ ament_target_dependencies(urg_node
   std_srvs
   urg_c
   urg_node_msgs
+  Boost
 )
 rclcpp_components_register_node(urg_node
   PLUGIN "urg_node::UrgNode"

--- a/package.xml
+++ b/package.xml
@@ -18,8 +18,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libboost-dev</build_depend>
+  <build_export_depend>libboost-dev</build_export_depend>
   <depend>builtin_interfaces</depend>
-  <depend>boost</depend>
   <depend>diagnostic_updater</depend>
   <depend>laser_proc</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
In an [ongoing effort](https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448) to reduce the footprint on the target systems, it is preferred to declare specific dependencies instead of generic ones.

This PR gets rid of the runtime dependency on boost completely and trims down the build dependencies to only the boost headers and no the boost libraries. "crc" being a header only part of boost, no library is required to use it. saves around 400MB in build environment.