### PR TITLE
Fixed segmentation fault caused by setSkip()

### DIFF
--- a/include/urg_node/urg_c_wrapper.h
+++ b/include/urg_node/urg_c_wrapper.h
@@ -155,7 +155,7 @@ public:
 
   bool setAngleLimitsAndCluster(double& angle_min, double& angle_max, int cluster);
 
-  bool setSkip(int skip);
+  void setSkip(int skip);
 
   ros::Duration computeLatency(size_t num_measurements);
 

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -865,7 +865,7 @@ bool URGCWrapper::setAngleLimitsAndCluster(double& angle_min, double& angle_max,
   return true;
 }
 
-bool URGCWrapper::setSkip(int skip)
+void URGCWrapper::setSkip(int skip)
 {
   skip_ = skip;
 }


### PR DESCRIPTION
On noetic and using build type release there is a segmentation fault also noted by [#76](https://github.com/ros-drivers/urg_node/issues/76).

This function as no return type causing undefined behavior.  The compiler even throws a warning about this. 

The return type is not required based on the implementation. This function has been declared as void.  Now the node runs as expected. 