### PR TITLE
Use Python 3 specifically in helper script

### DIFF
--- a/scripts/set_urg_ip.py
+++ b/scripts/set_urg_ip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2014 Unbounded Robotics Inc.
 # All right reserved.


### PR DESCRIPTION
ROS 2 only targets Python 3. Making the shebang specific will ensure it isn't accidentally executed using the Python 2 interpreter.

This should resolve the RPM build failures for RHEL 8: https://build.ros2.org/view/Rbin_rhel_el864/job/Rbin_rhel_el864__urg_node__rhel_8_x86_64__binary/