### PR TITLE
Install Python helper script using catkin_install_python() so the cor…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 ## Install script to set IP addresses
-install(PROGRAMS
+catkin_install_python(PROGRAMS
    scripts/set_urg_ip.py
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/scripts/set_urg_ip.py
+++ b/scripts/set_urg_ip.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
     sock.connect((args.ip, 10940))
 
     print("Updating settings")
-    sock.send(msg)
+    sock.send(msg.encode('utf-8'))
     try:
         sock.settimeout(5)
         returned = sock.recv(40)


### PR DESCRIPTION
…rect Python version is selected automatically; ensure socket sends message as byte object for Python3, while ensuring backwards compatability with Python2.