### PR TITLE
[ROS-O] drop obsolete c++11 flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED COMPONENTS
   diagnostic_updater dynamic_reconfigure laser_proc message_generation
   nodelet rosconsole roscpp sensor_msgs std_msgs std_srvs tf urg_c
 )
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11")
 
 # Dynamic reconfigure support
 generate_dynamic_reconfigure_options(cfg/URG.cfg)


### PR DESCRIPTION
c++17 works just fine and is needed on ubuntu 22.04.

Note that you do not want to merge this into a `kinetic-devel` branch as kinetic did not use c++11 by default yet.
It would be appropriate to create a new `melodic-devel` branch for this.