### PR TITLE
Reduce diagnostics publish rate

### DIFF
--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -340,7 +340,7 @@ void UrgNode::updateDiagnostics()
 {
   while (!close_diagnostics_) {
     diagnostic_updater_.force_update();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
 }
 


### PR DESCRIPTION
This is just a quick PR to increase the thread sleep in the diagnostics thread. Currently the diagnostics status is updated at ~96hz.  Which is way too fast and really messes with the Frequency Status Monitor which jumps between too low and too high. See the example below:

```
  name: 'urg_node_back_right_node: Laser Scan topic status'
  message: Frequency too low.
  hardware_id: L2206655
  values:
  - key: Events in window
    value: '1'
  - key: Events since startup
    value: '156'
  - key: Duration of window (s)
    value: '0.051235'
  - key: Actual frequency (Hz)
    value: '19.517923'
  - key: Target frequency (Hz)
    value: '33.333333'
  - key: Minimum acceptable frequency (Hz)
    value: '31.666667'
  - key: Maximum acceptable frequency (Hz)
    value: '35.000000'
---
  name: 'urg_node_back_right_node: Laser Scan topic status'
  message: Frequency too high.
  hardware_id: L2206655
  values:
  - key: Events in window
    value: '2'
  - key: Events since startup
    value: '157'
  - key: Duration of window (s)
    value: '0.051236'
  - key: Actual frequency (Hz)
    value: '39.034756'
  - key: Target frequency (Hz)
    value: '33.333333'
  - key: Minimum acceptable frequency (Hz)
    value: '31.666667'
  - key: Maximum acceptable frequency (Hz)
    value: '35.000000'
---
  name: 'urg_node_back_right_node: Laser Scan topic status'
  message: Frequency too high.
  hardware_id: L2206655
  values:
  - key: Events in window
    value: '2'
  - key: Events since startup
    value: '157'
  - key: Duration of window (s)
    value: '0.051214'
  - key: Actual frequency (Hz)
    value: '39.051837'
  - key: Target frequency (Hz)
    value: '33.333333'
  - key: Minimum acceptable frequency (Hz)
    value: '31.666667'
  - key: Maximum acceptable frequency (Hz)
    value: '35.000000'
---
  name: 'urg_node_back_right_node: Laser Scan topic status'
  message: Frequency too low.
  hardware_id: L2206655
  values:
  - key: Events in window
    value: '1'
  - key: Events since startup
    value: '157'
  - key: Duration of window (s)
    value: '0.051120'
  - key: Actual frequency (Hz)
    value: '19.561890'
  - key: Target frequency (Hz)
    value: '33.333333'
  - key: Minimum acceptable frequency (Hz)
    value: '31.666667'
  - key: Maximum acceptable frequency (Hz)
    value: '35.000000'
---
```