### PR TITLE
Empty return value from sendCommand causes a crash

### DIFF
--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -327,6 +327,11 @@ bool URGCWrapper::getAR00Status(URGStatus & status)
   // Get the response
   std::string response = sendCommand(str_cmd);
 
+  if (response.empty()) {
+    RCLCPP_WARN(logger_, "Received empty response from AR00 command");
+    return false;
+  }
+
   RCLCPP_DEBUG(logger_, "Full response: %s", response.c_str());
 
   // Strip STX and ETX before calculating the CRC.
@@ -413,6 +418,11 @@ bool URGCWrapper::getDL00Status(UrgDetectionReport & report)
 
   // Get the response
   std::string response = sendCommand(str_cmd);
+
+  if (response.empty()) {
+    RCLCPP_WARN(logger_, "Received empty response from DL00 command");
+    return false;
+  }
 
   RCLCPP_DEBUG(logger_, "Full response: %s", response.c_str());
 


### PR DESCRIPTION
A quick bug fix, I found that an error in the [sendCommand](https://github.com/ros-drivers/urg_node/blob/1166ab25aab1d085183f7f6de42d3bf562c127a7/src/urg_c_wrapper.cpp#L328) function in urg_c_wrapper returns an empty string. However none of the callers are checking for an empty string so this results in an unhandled std::out_of_range exception:

```
[urg_node_driver-25] [ERROR 1679511084.962595117] [urg_node_front_left_node]: Buffer creation bounds exceeded, shouldn't allocate: 4294967291 bytes (sendCommand() at /root/v2.0.6/src/urg_node/src/urg_c_wrapper.cpp:597)
[urg_node_driver-25] terminate called after throwing an instance of 'std::out_of_range'
[urg_node_driver-25]   what():  basic_string::erase: __pos (which is 18446744073709551615) > this->size() (which is 0)
[ERROR] [urg_node_driver-25]: process has died [pid 42882, exit code -6, cmd '/
```

This PR just adds an empty string check in the two callers to prevent the crash. There are probably not many people using the detailed status but we're using it on the UAM-05LP-T301 to get the error codes so very useful to get this fixed.
