### PR TITLE
Fixed signed to unsigned conversion error in sendCommand

### DIFF
--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -559,11 +559,11 @@ std::string URGCWrapper::sendCommand(std::string cmd)
 
   // All serial command structures start with STX + LEN as
   // the first 5 bytes, read those in.
-  size_t total_read_len = 0;
-  size_t read_len = 0;
+  ssize_t total_read_len = 0;
+  ssize_t read_len = 0;
   // Read in the header, make sure we get all 5 bytes expcted
   char recvb[5] = {0};
-  size_t expected_read = 5;
+  ssize_t expected_read = 5;
   while (total_read_len < expected_read) {
     read_len = read(sock, recvb + total_read_len, expected_read - total_read_len);  // READ STX
     total_read_len += read_len;


### PR DESCRIPTION
This PR fixes a bug in the [sendCommand](https://github.com/ros-drivers/urg_node/blob/1166ab25aab1d085183f7f6de42d3bf562c127a7/src/urg_c_wrapper.cpp#L328) function, socket read returns a sstize_t which was being converted to an unsigned (size_t). 

If a read error occurs it will return -1 which is converted to SIZE_MAX (18446744073709551615 on our machines) and then added to the total_read_len which wraps around to same value it had already (so the loop termination condition is never reached) and also fools the error if statement because it's greater than 0.

We occasionally have a lot of network traffic our robot which can lead to a few read errors when this happens the urg_node sometimes gets stuck in this loop because of the bug. With this fix the read error is handled properly and the node doesn't get stuck. 