### PR TITLE
Add expected size check for AR00 DL00 command from UAM protocol specification. 

### DIFF
--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -102,6 +102,9 @@ struct SerialConnection
   int serial_baud;
 };
 
+static const size_t AR00_PACKET_SIZE = 4379;
+static const size_t DL00_PACKET_SIZE = 1936;
+
 class URGCWrapper
 {
 public:

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -327,8 +327,9 @@ bool URGCWrapper::getAR00Status(URGStatus & status)
   // Get the response
   std::string response = sendCommand(str_cmd);
 
-  if (response.empty()) {
-    RCLCPP_WARN(logger_, "Received empty response from AR00 command");
+  if (response.empty() || response.size() < AR00_PACKET_SIZE) {
+    RCLCPP_WARN(logger_, "Invalid response from AR00 expected size: %lu actual: %lu",
+      AR00_PACKET_SIZE, response.size());
     return false;
   }
 
@@ -419,8 +420,9 @@ bool URGCWrapper::getDL00Status(UrgDetectionReport & report)
   // Get the response
   std::string response = sendCommand(str_cmd);
 
-  if (response.empty()) {
-    RCLCPP_WARN(logger_, "Received empty response from DL00 command");
+  if (response.empty() || response.size() < DL00_PACKET_SIZE) {
+    RCLCPP_WARN(logger_, "Invalid response from DL00 expected size: %lu actual: %lu",
+      DL00_PACKET_SIZE, response.size());
     return false;
   }
 

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -328,7 +328,8 @@ bool URGCWrapper::getAR00Status(URGStatus & status)
   std::string response = sendCommand(str_cmd);
 
   if (response.empty() || response.size() < AR00_PACKET_SIZE) {
-    RCLCPP_WARN(logger_, "Invalid response from AR00 expected size: %lu actual: %lu",
+    RCLCPP_WARN(
+      logger_, "Invalid response from AR00 expected size: %lu actual: %lu",
       AR00_PACKET_SIZE, response.size());
     return false;
   }
@@ -421,7 +422,8 @@ bool URGCWrapper::getDL00Status(UrgDetectionReport & report)
   std::string response = sendCommand(str_cmd);
 
   if (response.empty() || response.size() < DL00_PACKET_SIZE) {
-    RCLCPP_WARN(logger_, "Invalid response from DL00 expected size: %lu actual: %lu",
+    RCLCPP_WARN(
+      logger_, "Invalid response from DL00 expected size: %lu actual: %lu",
       DL00_PACKET_SIZE, response.size());
     return false;
   }

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -155,6 +155,13 @@ bool UrgNode::updateStatus()
     device_status_ = urg_->getSensorStatus();
 
     if (detailed_status_) {
+      // check product supports this command
+      if (product_name_.find("UAM") != 0) {
+        RCLCPP_WARN(
+          this->get_logger(), "Detailed status only available for UAM series, your model is %s",
+          product_name_.c_str());
+        return false;
+      }
       URGStatus status;
       if (urg_->getAR00Status(status)) {
         urg_node_msgs::msg::Status msg;


### PR DESCRIPTION
I was a bit slow when I fixed [this issue](https://github.com/ros-drivers/urg_node/pull/104) and didn't think to add a check for the message length so there's still a potential for it to fail with a std::length error. This PR adds a packet length check for the AR00 and DL00 from the UAM protocol specification. 

The UAM manual doesn't seem to be easily available online so I've added some screen grabs of the two commands for reference:
### AR00
![image (19)](https://user-images.githubusercontent.com/2834094/227500383-0f95e737-f4d2-469b-9ae3-f8b2727b2f60.png)
### DL00
![image (20)](https://user-images.githubusercontent.com/2834094/227500380-c018c3e4-f189-4496-81a3-2502b6d223b7.png)

