### PR TITLE
[ROS-O] remove implicitly used boost::bind symbols

### DIFF
--- a/src/urg_node_driver.cpp
+++ b/src/urg_node_driver.cpp
@@ -539,7 +539,7 @@ void UrgNode::scanThread()
       srv_.reset(new dynamic_reconfigure::Server<urg_node::URGConfig>(pnh_));
       // Configure limits (Must do this after creating the urgwidget)
       update_reconfigure_limits();
-      srv_->setCallback(boost::bind(&UrgNode::reconfigure_callback, this, _1, _2));
+      srv_->setCallback([this](auto cfg, int lvl){ return reconfigure_callback(cfg, lvl); });
     }
 
     // Before starting, update the status


### PR DESCRIPTION
These symbols were implicitly included through a ros_comm header include and ros-o will likely change that include soon
https://github.com/ros-o/ros_comm/pull/3 due to an excessive amount of warnings.