### PR TITLE
added scan_topic parameter

### DIFF
--- a/include/urg_node/urg_node.hpp
+++ b/include/urg_node/urg_node.hpp
@@ -162,6 +162,8 @@ private:
   /** The laser tf frame id. */
   std::string laser_frame_id_;
 
+  std::string scan_topic_;
+
   volatile bool service_yield_;
 
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr laser_pub_;

--- a/launch/urg_node_ethernet.yaml
+++ b/launch/urg_node_ethernet.yaml
@@ -6,6 +6,7 @@ urg_node:
     ip_port: 10940
     serial_baud: 115200
     laser_frame_id: "laser"
+    scan_topic: "scan"
     calibrate_time: false
     default_user_latency: 0.0
     diagnostics_tolerance: 0.05

--- a/launch/urg_node_serial.yaml
+++ b/launch/urg_node_serial.yaml
@@ -6,6 +6,7 @@ urg_node:
     serial_port: "/dev/ttyACM0"
     serial_baud: 115200
     laser_frame_id: "laser"
+    scan_topic: "scan"
     calibrate_time: false
     default_user_latency: 0.0
     diagnostics_tolerance: 0.05

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -71,6 +71,7 @@ UrgNode::UrgNode(const rclcpp::NodeOptions & node_options)
   skip_(0),
   default_user_latency_(0.0),
   laser_frame_id_("laser"),
+  scan_topic_("scan"),
   service_yield_(true)
 {
   (void) synchronize_time_;
@@ -83,6 +84,7 @@ void UrgNode::initSetup()
   ip_address_ = this->declare_parameter<std::string>("ip_address", ip_address_);
   ip_port_ = this->declare_parameter<int>("ip_port", ip_port_);
   laser_frame_id_ = this->declare_parameter<std::string>("laser_frame_id", laser_frame_id_);
+  scan_topic_ = this->declare_parameter<std::string>("scan_topic", scan_topic_);
   serial_port_ = this->declare_parameter<std::string>("serial_port", serial_port_);
   serial_baud_ = this->declare_parameter<int>("serial_baud", serial_baud_);
   calibrate_time_ = this->declare_parameter<bool>("calibrate_time", calibrate_time_);
@@ -109,7 +111,7 @@ void UrgNode::initSetup()
     echoes_pub_ =
       std::make_unique<laser_proc::LaserPublisher>(this->get_node_topics_interface(), 20);
   } else {
-    laser_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", 20);
+    laser_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(scan_topic_, 20);
   }
 
   status_service_ = this->create_service<std_srvs::srv::Trigger>(


### PR DESCRIPTION
Hello,
it would be useful to add "scan_topic" as a  re-configurable parameter, to allow people to have more flexibility when choosing the scan topic name.
I tested it with:
- Ubuntu version : **Ubuntu 22.04.4 LTS** 
- ROS **Humble**
- Laser Model: **Hokuyo URG-04LX-UG01**
 